### PR TITLE
Add context manger helper 

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,11 @@
+Here are some notes for developing `regret`.
+
+API docstring are written using Sphinx / ReStructredText format.
+
+Before a commit, stage all files and run all the tests with::
+
+    tox -e tests,style
+
+To run a single test use::
+
+    $ python -m virtue regret.tests.test_api.TestModuleDeprecation.test_deprecated_module_reference

--- a/regret/testing.py
+++ b/regret/testing.py
@@ -2,6 +2,8 @@
 Helpers for testing your regret.
 """
 from contextlib import contextmanager
+import sys
+import warnings
 
 import attr
 
@@ -44,3 +46,181 @@ class Recorder:
         Expect no deprecations to be emitted.
         """
         return self.expect_deprecations()
+
+
+class _Warning:
+    """
+    It represents one warning emitted through the standard Python
+    warning system.
+
+    @ivar message: The string which was passed as the message parameter to
+        L{warnings.warn}.
+
+    @ivar category: The L{Warning} subclass which was passed as the category
+        parameter to L{warnings.warn}.
+
+    @ivar filename: The name of the file containing the definition of the code
+        object which was C{stacklevel} frames above the call to
+        L{warnings.warn}, where C{stacklevel} is the value of the C{stacklevel}
+        parameter passed to L{warnings.warn}.
+
+    @ivar lineno: The source line associated with the active instruction of the
+        code object object which was C{stacklevel} frames above the call to
+        L{warnings.warn}, where C{stacklevel} is the value of the C{stacklevel}
+        parameter passed to L{warnings.warn}.
+    """
+
+    def __init__(self, message, category, filename, lineno):
+        self.message = message
+        self.category = category
+        self.filename = filename
+        self.lineno = lineno
+
+    def __repr__(self):
+        """
+        Test failure reporting friendly representation of the captured warning.
+        """
+        return (
+            f'{self.category}"{self.message}"\n'
+            f'{self.filename}:{self.lineno}\n'
+            )
+
+
+def _reset_warnings():
+    """
+    Disable the per-module cache for every module otherwise if the warning
+    which the caller is expecting us to collect was already emitted it won't
+    be re-emitted by the call to f which happens below.
+    """
+    for v in list(sys.modules.values()):
+        if v is not None:
+            try:
+                v.__warningregistry__ = None
+            except BaseException:
+                # Don't specify a particular exception type to handle in case
+                # some wacky object raises some wacky exception in response to
+                # the setattr attempt.
+                pass
+
+
+class WarningsCollector:
+    """
+    Helper for catching and verifying emitted warnings inside the testing
+    context manager.
+
+    For now, usage is supported only as a context manager.
+    In the future it can provide explicit `start` and `stop` methods to
+    help usage outside of a context.
+    """
+    def __init__(self):
+        self._queue = []
+
+    def _append(self, warning):
+        """
+        Private method used together with the context manager.
+        """
+        self._queue.append(warning)
+
+    def expect_regret(self, target, replacement=None, source=None, lineno=None):
+        """
+        Expect that a regret warning was emitted.
+        """
+        message = f'{target} is deprecated.'
+        if replacement:
+            message += f' Please use {replacement} instead.'
+
+        self.expect(
+            message,
+            category=DeprecationWarning,
+            source=source,
+            lineno=lineno,
+            )
+
+    def expect(
+        self, message, category=DeprecationWarning, source=None, lineno=None,
+            ):
+        """
+        Check the first warnings that was emitted and then remove it from the
+        expectation list.
+
+        `message` is the expected message contained by the emitted warning.
+
+        `category` is the class of the emitted deprecation. Defaults to
+        `DeprecationWarning`.
+
+        `source` is the name of the Python module from which the warning is
+        emitted.
+        Don't include the full path or the `.py` extension.
+        It is designed to make it easy to write tests on Unix and Windows.
+
+        `lineno` is the line number from where the warning was emitted.
+
+        It will accept any `source` or `lineno` when no expected values are
+        provided for them.
+        """
+        actual = self._queue.pop(0)
+
+        if message != actual.message:
+            raise AssertionError(
+                f'Expecting warning with message "{message}". '
+                f'Got "{actual.message}".')
+
+        if actual.category != category:
+            raise AssertionError(
+                f'Expecting warning as "{category}". Got "{actual.category}".')
+
+        if source:
+            if not actual.filename.endswith(f'{source}.py'):
+                raise AssertionError(
+                    f'Expecting warning from path ending with "{source}.py". '
+                    f'Got "{actual.filename}".')
+
+        if lineno:
+            if actual.lineno != lineno:
+                raise AssertionError(
+                    f'Expecting warning at line "{lineno}". '
+                    f'Got "{actual.lineno}".')
+
+    def expect_clean(self):
+        """
+        Expect no warning were left unverified.
+        """
+        if self._queue:
+            raise AssertionError(
+                'Warnings queue was not completely checked.\n'
+                + repr(self._queue))
+
+
+@contextmanager
+def collect_warnings():
+    """
+    Catches the warnings emitted inside the context.
+
+    Returns a `WarningsCollector` that is used inside a context to check the
+    emitted warnings.
+
+    All warnings must the checked  before the end of the context.
+    """
+    collector = WarningsCollector()
+
+    def catch_warning(
+            warning, category, filename, lineno, file=None, line=None):
+        """
+        Injected into Python to allow catching all warnings.
+        """
+        assert isinstance(warning, Warning)
+        collector._append(_Warning(str(warning), category, filename, lineno))
+
+    _reset_warnings()
+
+    origFilters = warnings.filters[:]
+    origShow = warnings.showwarning
+    warnings.simplefilter("always")
+    try:
+        warnings.showwarning = catch_warning
+        yield collector
+    finally:
+        warnings.filters[:] = origFilters
+        warnings.showwarning = origShow
+        collector.expect_clean()
+

--- a/regret/tests/test_testing.py
+++ b/regret/tests/test_testing.py
@@ -1,13 +1,19 @@
 """
 Integration tests for the testing helper(s).
 """
+import warnings
+
 from unittest import TestCase
 
+import regret
 from regret import Deprecator, emitted, testing
 
 
 def calculate():
     return 12
+
+def replacement_calculate():
+    return 11
 
 
 class TestRecorder(TestCase):
@@ -108,3 +114,112 @@ class TestRecorder(TestCase):
         with self.assertRaises(testing.ExpectedDifferentDeprecations):
             with recorder.expect_clean():
                 deprecated()
+
+
+class TestWarnigsCollector(TestCase):
+    """
+    Tests for `collect_warnings` helper.
+    """
+
+    def test_no_warnings(self):
+        """
+        No error is raised if no warning is raised inside the context
+        manager.
+        """
+        with testing.collect_warnings():
+            """
+            No warning emitted here.
+            """
+
+    def test_fail_on_unchecked_warnings(self):
+        """
+        No error is raised if no warning is raised inside the context
+        manager.
+        """
+        with self.assertRaises(AssertionError) as context:
+            with testing.collect_warnings():
+                warnings.warn("A warning that is not checked.")
+
+        self.assertTrue(context.exception.args[0].startswith(
+            'Warnings queue was not completely checked.'))
+
+    def test_expect_warning(self):
+        """
+        The context manager returns a helper that can be used to
+        assert the emitted warnings.
+        """
+        with testing.collect_warnings() as collector:
+            warnings.warn("A warning that is checked.", UserWarning)
+
+            collector.expect(
+                'A warning that is checked.', category=UserWarning)
+
+    def test_expect_warning_unchecked(self):
+        """
+        When an emitted warning is left unchecked, an AssertionError is
+        raised when the context exists.
+        """
+        with self.assertRaises(AssertionError) as context:
+            with testing.collect_warnings() as collector:
+                warnings.warn("A warning that is checked.", UserWarning)
+                warnings.warn("A warning that is checked.", UserWarning)
+
+                collector.expect(
+                    'A warning that is checked.', category=UserWarning)
+
+        self.assertTrue(context.exception.args[0].startswith(
+            'Warnings queue was not completely checked.'))
+
+    def test_expect_regret(self):
+        """
+        It provide a helper to expect a warning raised by regret.
+        """
+        deprecated = regret.callable(version="1.2.0")(calculate)
+
+        with testing.collect_warnings() as collector:
+            deprecated()
+
+            collector.expect_regret('calculate')
+
+    def test_expect_regret_with_replacement(self):
+        """
+        It provide a helper to expect a warning raised by regret.
+        """
+        deprecated = regret.callable(
+            version="1.2.0",
+            replacement=replacement_calculate,
+            )(calculate)
+
+        with testing.collect_warnings() as collector:
+            deprecated()
+
+            collector.expect_regret(
+                'calculate', replacement='replacement_calculate')
+
+    def test_expect_regret_source(self):
+        """
+        It provide a helper to expect a warning raised by regret from
+        a specific source file.
+        """
+        deprecated = regret.callable(version="1.2.0")(calculate)
+
+        with testing.collect_warnings() as collector:
+            deprecated()
+
+            collector.expect_regret('calculate', source='test_testing')
+
+    def test_expect_regret_source_mismatch(self):
+        """
+        It raised AssertionError when the expected source is different than
+        the source associated with the regret.
+        """
+        deprecated = regret.callable(version="1.2.0")(calculate)
+
+        with self.assertRaises(AssertionError) as context:
+            with testing.collect_warnings() as collector:
+                deprecated()
+
+                collector.expect_regret('calculate', source='bad_source')
+
+        self.assertTrue(context.exception.args[0].startswith(
+            'Expecting warning from path ending with "bad_source.py". Got '))


### PR DESCRIPTION
Scope
=====

Make it easy to test deprecation warnings emitted by regret using any testing framework.

It should  allow testing default `regret` decorators without any custom recorder.


State of the world
==============

stdlib has `warnings.catch_warnings` https://docs.python.org/3/library/warnings.html#testing-warnings

pytest already has good support for catching warnings - https://docs.pytest.org/en/stable/reference.html#pytest-warns

pytest also has great documentation https://docs.pytest.org/en/stable/warnings.html

trial (twisted) has a helper for the default test case.


Changes
=======

Based on  the code from trial... that uses stdlib.

The context manager should make it easy to use stdlib unittest to assert warning emitted by `regret`.

The test assertion  / expectation is using fully resolved text for the replacement to make sure message is raised as expected.

